### PR TITLE
Added CF templates

### DIFF
--- a/cloudformation/int_calc_solution.py
+++ b/cloudformation/int_calc_solution.py
@@ -1,0 +1,23 @@
+import datetime
+import sys
+def process_api_call(params):
+   x = int(params['x'])
+   y = int(params['y'])
+   operator = params['operator']
+   result = None
+   if (operator == "add"):
+       result = x + y
+   elif (operator == "sub"):
+       result = x - y
+   return result
+
+def lambda_handler(event, context):
+    returnCode = 200
+    result = process_api_call(event['queryStringParameters'])
+    #result = 'lambda ' + context.function_name + ' was called at ' + datetime.datetime.now().strftime('%c')
+    print(result)
+    return {
+      'statusCode': returnCode,
+      'body': '{0}'.format(result)
+    }
+

--- a/cloudformation/spa2017-apigateway-lambda.template
+++ b/cloudformation/spa2017-apigateway-lambda.template
@@ -1,0 +1,199 @@
+{
+	 "Description" : "Setup stack for API part of serverless exercise",
+
+	 "Parameters" : {
+	 	 "namePrefixParameter" : {
+		  	"Type" : "String",
+			  "Default" : "spa2017",
+			  "Description" : "Tag to add to the front of item names"
+		  }
+	  },
+
+    "Resources" : {
+    	"theLambdaApi" : {
+    		"Type" : "AWS::ApiGateway::RestApi",
+    		"Properties" : {
+    			"Name" : { "Fn::Join" : ["", [
+    				{"Ref" : "namePrefixParameter"},
+    				"-",
+    				"LambdaApi"
+    				]]
+    			},
+    			"Description" : "API for calling lambda functions",
+    			"FailOnWarnings" : "true"
+    		}
+    	},
+    	"theApiHandlerLambda" : {
+    		"Type" : "AWS::Lambda::Function",
+    		"Properties" : {
+    			"FunctionName" : { "Fn::Join" : ["", [
+    				{"Ref" : "namePrefixParameter"},
+    				"-",
+    				"ApiHandlerLambda"
+    				]]
+    			},
+    			"Code" : { "ZipFile" :  { "Fn::Join" : ["\n", [
+    				         "import datetime",
+    				         "def process_api_call(params):",
+    				         "   return",
+    				         "",
+    			             "def lambda_handler(event, context):",
+    			             "   #result = process_api_call(event['queryStringParameters'])",
+    			             "   result = 'lambda ' + context.function_name + ' was called at ' + datetime.datetime.now().strftime('%c')",
+                             "   print(result)",
+                             "   return {",
+                             "      'statusCode': 200,",
+                             "      'body': '{0}'.format(result)",
+                             "   }"
+                             ]]}
+                          },
+    			"Handler" : "index.lambda_handler",
+    			"MemorySize" : "128",
+    			"Role" : { "Fn::GetAtt": ["theLambdaExecutionRole", "Arn"]},
+    			"Runtime" : "python3.6"
+
+    		}
+    	},
+    	"theLambdaExecutionRole" : {
+    		"Type" : "AWS::IAM::Role",
+    		"Properties" : {
+    			"RoleName" : { "Fn::Join" : ["", [
+    				{"Ref" : "namePrefixParameter"},
+    				"-",
+    				"LambdaExecutionRole"
+    				]]
+    			},
+    			"AssumeRolePolicyDocument" : {
+    				"Version" : "2012-10-17",
+    				"Statement" : [ {
+    					"Effect" : "Allow",
+    					"Principal" : { "Service" : ["lambda.amazonaws.com"]},
+    					"Action" : ["sts:AssumeRole"]
+    				}]
+
+    			},
+    			"ManagedPolicyArns" : ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+    		}
+    	} ,
+    	"theApiHandlerLambdaPermission": {
+  			"Type": "AWS::Lambda::Permission",
+			"Properties": {
+    			"Action": "lambda:invokeFunction",
+    			"FunctionName": {"Fn::GetAtt": ["theApiHandlerLambda", "Arn"]},
+    			"Principal": "apigateway.amazonaws.com",
+    			"SourceArn": {"Fn::Join": ["", 
+      				["arn:aws:execute-api:", {"Ref": "AWS::Region"}, ":", {"Ref": "AWS::AccountId"}, ":", {"Ref": "theLambdaApi"}, "/*"]
+    			]}
+  			}
+		},
+		"theLambdaApiStage": {
+  			"DependsOn" : ["theApiGatewayAccount"],
+  			"Type": "AWS::ApiGateway::Stage",
+  			"Properties": {
+    			"DeploymentId": {"Ref": "theApiDeployment"},
+    			"MethodSettings": [{
+      				"DataTraceEnabled": true,
+      				"HttpMethod": "GET",
+      				"LoggingLevel": "INFO",
+      				"ResourcePath": "/*"
+    			}],
+    			"RestApiId": {"Ref": "theLambdaApi"},
+    			"StageName": "LATEST"
+  			}
+		},
+		"theApiGatewayCloudWatchLogsRole": {
+  			"Type": "AWS::IAM::Role",
+  			"Properties": {
+  				"RoleName" : { "Fn::Join" : ["", [
+    				{"Ref" : "namePrefixParameter"},
+    				"-",
+    				"ApiGatewayCloudWatchLogsRole"
+    				]]
+    			},
+    			"AssumeRolePolicyDocument": {
+      				"Version": "2012-10-17",
+      				"Statement": [{
+        				"Effect": "Allow",
+        					"Principal": { "Service": ["apigateway.amazonaws.com"] },
+        					"Action": ["sts:AssumeRole"]
+      				}]
+    			},
+    			"Policies": [{
+      				"PolicyName": "ApiGatewayLogsPolicy",
+      				"PolicyDocument": {
+        				"Version": "2012-10-17",
+        				"Statement": [{
+          					"Effect": "Allow",
+          					"Action": [
+            					"logs:CreateLogGroup",
+            					"logs:CreateLogStream",
+            					"logs:DescribeLogGroups",
+            					"logs:DescribeLogStreams",
+            					"logs:PutLogEvents",
+            					"logs:GetLogEvents",
+            					"logs:FilterLogEvents"
+          					],
+          					"Resource": "*"
+        				}]
+      				}
+    			}]
+  			}
+		},
+		"theApiGatewayAccount" : {
+			"Type" : "AWS::ApiGateway::Account",
+			"Properties" : {
+				"CloudWatchRoleArn" : {"Fn::GetAtt" : ["theApiGatewayCloudWatchLogsRole", "Arn"]}
+			}
+		},
+		"theApiDeployment" : {
+			"Type" : "AWS::ApiGateway::Deployment",
+			"DependsOn" : ["theLambdaCalcRequestMethod"],
+			"Properties" : {
+				"RestApiId" : {"Ref" : "theLambdaApi"},
+				"StageName" : "UnusedStageName"
+			}
+		},
+		"theLambdaApiResource" : {
+			"Type" : "AWS::ApiGateway::Resource",
+			"Properties" : {
+				"RestApiId" : {"Ref" : "theLambdaApi"},
+				"ParentId" : {"Fn::GetAtt" : ["theLambdaApi", "RootResourceId"]},
+				"PathPart" : "int_calc"
+			}
+		},
+		"theLambdaCalcRequestMethod" : {
+			"DependsOn" : "theApiHandlerLambdaPermission",
+			"Type" : "AWS::ApiGateway::Method",
+			"Properties" : {
+				"AuthorizationType" : "NONE",
+				"HttpMethod" : "GET",
+				"RequestParameters" : {
+					"method.request.querystring.x" : true,
+					"method.request.querystring.y" : true,
+					"method.request.querystring.operator" : true
+				},
+				"ResourceId" : {"Ref" : "theLambdaApiResource"},
+				"RestApiId"  : {"Ref" : "theLambdaApi"},
+				"Integration" : {
+					"Type" : "AWS",
+					"IntegrationHttpMethod" : "POST",
+					"Uri" : {
+						"Fn::Join" : ["", [
+							"arn:aws:apigateway:",
+							{"Ref" : "AWS::Region"},
+							":lambda:path/2015-03-31/functions/",
+							{"Fn::GetAtt" : ["theApiHandlerLambda", "Arn"]},
+							"/invocations"
+						]]
+					},
+					"IntegrationResponses" : [{
+						"StatusCode" : 200
+					}]
+				},
+				"MethodResponses" : [{
+					"StatusCode" : 200
+				}]
+			}
+		}
+  }
+}

--- a/cloudformation/spa2017-apigateway-lambda.template
+++ b/cloudformation/spa2017-apigateway-lambda.template
@@ -175,7 +175,7 @@
 				"ResourceId" : {"Ref" : "theLambdaApiResource"},
 				"RestApiId"  : {"Ref" : "theLambdaApi"},
 				"Integration" : {
-					"Type" : "AWS",
+					"Type" : "AWS_PROXY",
 					"IntegrationHttpMethod" : "POST",
 					"Uri" : {
 						"Fn::Join" : ["", [

--- a/cloudformation/spa2017-dynamodb-lambda.template
+++ b/cloudformation/spa2017-dynamodb-lambda.template
@@ -21,11 +21,12 @@
     			},
     		   "AttributeDefinitions" : [ {"AttributeName" : "calc_id", "AttributeType" : "S"}, 
     		                              {"AttributeName" : "calc_timestamp", "AttributeType" : "S"}],
-               "KeySchema" : [ {"AttributeName" : "calc_id", "KeyType" : "HASH"}, 
-            	               {"AttributeName" : "calc_timestamp", "KeyType" : "RANGE"}],
-               "ProvisionedThroughput" : { "ReadCapacityUnits" : 1, "WriteCapacityUnits" : 1}
-            }
-        },
+           "KeySchema" : [ {"AttributeName" : "calc_id", "KeyType" : "HASH"}, 
+            	             {"AttributeName" : "calc_timestamp", "KeyType" : "RANGE"}],
+            "ProvisionedThroughput" : { "ReadCapacityUnits" : 1, "WriteCapacityUnits" : 1},
+            "StreamSpecification" : { "StreamViewType" : "NEW_IMAGE"}
+          }
+      },
     	"theSummaryTable" : {
  			 "Type" : "AWS::DynamoDB::Table",
   			 "Properties" : {
@@ -42,6 +43,77 @@
                "ProvisionedThroughput" : { "ReadCapacityUnits" : 1, "WriteCapacityUnits" : 1}
             }
 
+        },
+        "theLambdaExecutionRole" : {
+          "Type" : "AWS::IAM::Role",
+          "Properties" : {
+            "RoleName" : { "Fn::Join" : ["", [
+              {"Ref" : "namePrefixParameter"},
+              "-",
+              "DynamoLambdaExecutionRole"
+            ]]
+            },
+            "AssumeRolePolicyDocument" : {
+              "Version" : "2012-10-17",
+              "Statement" : [ {
+                "Effect" : "Allow",
+                "Principal" : { "Service" : ["lambda.amazonaws.com"]},
+                "Action" : ["sts:AssumeRole"]
+              }]
+            },
+            "ManagedPolicyArns" : ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+            "Policies": [{
+              "PolicyName": "LambdaDynamoAccessPolicy",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": [
+                      "dynamodb:DescribeStream",
+                      "dynamodb:GetItem",
+                      "dynamodb:GetRecords",
+                      "dynamodb:GetShardIterator",
+                      "dynamodb:ListStreams",
+                      "dynamodb:PutItem"
+                    ],
+                    "Resource": "arn:aws:dynamodb:*:*:table/*"
+                }]
+              }
+            }]
+          }
+        },
+      "theDynamoChangeHandlerLambda" : {
+        "Type" : "AWS::Lambda::Function",
+        "Properties" : {
+          "FunctionName" : { "Fn::Join" : ["", [
+            {"Ref" : "namePrefixParameter"},
+            "-",
+            "DynamoChangeHandlerLambda"
+            ]]
+          },
+          "Code" : { "ZipFile" :  { "Fn::Join" : ["\n", [
+                     "from __future__ import print_function",
+                     "",
+                       "def lambda_handler(event, context):",
+                       "    for record in event['Records']:",
+                       "        print('processed record with event ID {0} and name {1}'.format(record['eventID'], record['eventName']))",
+                       "    print('Successfully processed %s records.' % str(len(event['Records'])))"
+                       ]]}
+                    },
+          "Handler" : "index.lambda_handler",
+          "MemorySize" : "128",
+          "Role" : { "Fn::GetAtt": ["theLambdaExecutionRole", "Arn"]},
+          "Runtime" : "python3.6"
         }
+      },
+      "theDynamoLambdaMapping" : {
+        "Type" : "AWS::Lambda::EventSourceMapping",
+        "Properties" : {
+          "Enabled" : "True",
+          "EventSourceArn" : { "Fn::GetAtt": ["theCalculationTable", "StreamArn"]},
+          "FunctionName" : { "Fn::GetAtt": ["theDynamoChangeHandlerLambda", "Arn"]},
+          "StartingPosition" : "LATEST"
+        }
+      }
     }
 }

--- a/cloudformation/spa2017-dynamodb-lambda.template
+++ b/cloudformation/spa2017-dynamodb-lambda.template
@@ -1,0 +1,47 @@
+{
+	"Description" : "Setup stack for DynamoDB part of serverless exercise",
+
+	"Parameters" : {
+		"namePrefixParameter" : {
+			"Type" : "String",
+			"Default" : "spa2017",
+			"Description" : "Tag to add to the front of item names"
+		}
+	},
+
+    "Resources" : {
+    	"theCalculationTable" : {
+ 			 "Type" : "AWS::DynamoDB::Table",
+  			 "Properties" : {
+  			   "TableName": { "Fn::Join" : ["", [
+    				{"Ref" : "namePrefixParameter"},
+    				"-",
+    				"CalculationTable"
+    				]]
+    			},
+    		   "AttributeDefinitions" : [ {"AttributeName" : "calc_id", "AttributeType" : "S"}, 
+    		                              {"AttributeName" : "calc_timestamp", "AttributeType" : "S"}],
+               "KeySchema" : [ {"AttributeName" : "calc_id", "KeyType" : "HASH"}, 
+            	               {"AttributeName" : "calc_timestamp", "KeyType" : "RANGE"}],
+               "ProvisionedThroughput" : { "ReadCapacityUnits" : 1, "WriteCapacityUnits" : 1}
+            }
+        },
+    	"theSummaryTable" : {
+ 			 "Type" : "AWS::DynamoDB::Table",
+  			 "Properties" : {
+  			   "TableName": { "Fn::Join" : ["", [
+    				{"Ref" : "namePrefixParameter"},
+    				"-",
+    				"SummaryTable"
+    				]]
+    			},
+    		   "AttributeDefinitions" : [ {"AttributeName" : "summary_id", "AttributeType" : "S"}, 
+    		                              {"AttributeName" : "summary_timestamp", "AttributeType" : "S"}],
+               "KeySchema" : [ {"AttributeName" : "summary_id", "KeyType" : "HASH"}, 
+            	               {"AttributeName" : "summary_timestamp", "KeyType" : "RANGE"}],
+               "ProvisionedThroughput" : { "ReadCapacityUnits" : 1, "WriteCapacityUnits" : 1}
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Hi Andy,

Cloud Formation templates for consideration - they're both complete, in that they create empty lambdas that just print messages, with all of the other objects you need.  The API Gateway template creates the lambda and (complex) plumbing to allow it to be invoked from a public HTTP endpoint.  The DynamoDB template creates two tables and a lambda, attached to the change stream from one of the tables.

The idea is that these set up a working environment, into which they can copy and paste further lambda code, so avoiding setup errors in the console.

Might make things easier, might complicate things!  See what you think.